### PR TITLE
fix(systemd-networkd-watcher): require systemd-networkd

### DIFF
--- a/recipes-core/systemd-conf/files/systemd-networkd-watcher.service
+++ b/recipes-core/systemd-conf/files/systemd-networkd-watcher.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Update systemd-networkd on Change
-After=network.target
+Requires=systemd-networkd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Require systemd-networkd instead of network.target

Signed-off-by: Corey Cothrum <contact@coreycothrum.com>